### PR TITLE
fixes array serialization problem

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -489,7 +489,7 @@ class Pusher implements LoggerAwareInterface
         $post_params = array();
         $post_params['name'] = $event;
         $post_params['data'] = $data_encoded;
-        $post_params['channels'] = $channels;
+        $post_params['channels'] = array_values($channels);
 
         if ($socket_id !== null) {
             $post_params['socket_id'] = $socket_id;


### PR DESCRIPTION
when channels array is not zero indexed it gets serialized as an object which is rejected by the pusher API. array_values reindexes pusher channel array into 0-indexed array with sequential keys